### PR TITLE
Fix Shapeshift Bugs and Small Changes for Madmate

### DIFF
--- a/TONX/Modules/Camouflage.cs
+++ b/TONX/Modules/Camouflage.cs
@@ -68,7 +68,7 @@ public static class Camouflage
             Utils.NotifyRoles(NoCache: true);
         }
     }
-    public static void RpcSetSkin(PlayerControl target, bool ForceRevert = false, bool RevertToDefault = false)
+    public static void RpcSetSkin(PlayerControl target, bool ForceRevert = false, bool RevertToDefault = false, bool ForceChange = false)
     {
         if (!(AmongUsClient.Instance.AmHost && (Options.CommsCamouflage.GetBool() || CustomRoles.Concealer.IsExist(true)))) return;
         if (target == null) return;
@@ -101,7 +101,7 @@ public static class Camouflage
         }
 
 
-        if (newOutfit.Compare(target.Data.DefaultOutfit)) return;
+        if (newOutfit.Compare(target.Data.DefaultOutfit) && !ForceChange) return;
 
         Logger.Info($"newOutfit={newOutfit.GetString()}", "RpcSetSkin");
 

--- a/TONX/Modules/GameOptionsSender/GameOptionsSender.cs
+++ b/TONX/Modules/GameOptionsSender/GameOptionsSender.cs
@@ -31,12 +31,14 @@ public abstract class GameOptionsSender
     public virtual void SendGameOptions()
     {
         var opt = BuildGameOptions();
+        var currentGameMode = AprilFoolsMode.IsAprilFoolsModeToggledOn //April fools mode toggled on by host
+            ? opt.AprilFoolsOnMode : opt.GameMode; //Change game mode, same as well as in "RpcSyncSettings()"
 
         // option => byte[]
         MessageWriter writer = MessageWriter.Get(SendOption.None);
         writer.Write(opt.Version);
         writer.StartMessage(0);
-        writer.Write((byte)opt.GameMode);
+        writer.Write((byte)currentGameMode);
         if (opt.TryCast<NormalGameOptionsV08>(out var normalOpt))
             NormalGameOptionsV08.Serialize(writer, normalOpt);
         else if (opt.TryCast<HideNSeekGameOptionsV08>(out var hnsOpt))

--- a/TONX/Modules/Utils.cs
+++ b/TONX/Modules/Utils.cs
@@ -870,7 +870,7 @@ public static class Utils
             + $"\n  ○ /exe {GetString("Command.exe")}"
             + $"\n  ○ /level {GetString("Command.level")}"
             + $"\n  ○ /id {GetString("Command.idlist")}"
-            //  + $"\n  ○ /qq {GetString("Command.qq")}"
+            // + $"\n  ○ /qq {GetString("Command.qq")}"
             + $"\n  ○ /dump {GetString("Command.dump")}"
             + $"\n  ○ /up {GetString("Command.up")}"
             , ID);

--- a/TONX/Patches/PlayerControlPatch.cs
+++ b/TONX/Patches/PlayerControlPatch.cs
@@ -307,7 +307,7 @@ class ShapeshiftPatch
         },
         1.2f, "ShapeShiftNotify");
 
-        // 变形后刷新玩家皮肤
+        // 变形后刷新玩家小黑人状态
         if (shapeshifting && Camouflage.IsCamouflage)
         {
             _ = new LateTask(() =>

--- a/TONX/Patches/PlayerControlPatch.cs
+++ b/TONX/Patches/PlayerControlPatch.cs
@@ -300,13 +300,14 @@ class ShapeshiftPatch
 
         if (!shapeshifting) Camouflage.RpcSetSkin(__instance);
 
-        //変身解除のタイミングがずれて名前が直せなかった時のために強制書き換え
+        // 变形后刷新玩家名字
         _ = new LateTask(() =>
         {
             Utils.NotifyRoles(NoCache: true);
         },
         1.2f, "ShapeShiftNotify");
 
+        // 变形后刷新玩家皮肤
         if (shapeshifting && Camouflage.IsCamouflage)
         {
             _ = new LateTask(() =>

--- a/TONX/Patches/PlayerControlPatch.cs
+++ b/TONX/Patches/PlayerControlPatch.cs
@@ -301,13 +301,22 @@ class ShapeshiftPatch
         if (!shapeshifting) Camouflage.RpcSetSkin(__instance);
 
         //変身解除のタイミングがずれて名前が直せなかった時のために強制書き換え
-        if (!shapeshifting)
+        _ = new LateTask(() =>
+        {
+            Utils.NotifyRoles(NoCache: true);
+        },
+        1.2f, "ShapeShiftNotify");
+
+        if (shapeshifting && Camouflage.IsCamouflage)
         {
             _ = new LateTask(() =>
             {
-                Utils.NotifyRoles(NoCache: true);
+                if (GameStates.IsInTask)
+                {
+                    Camouflage.RpcSetSkin(__instance, ForceChange: true);
+                } 
             },
-            1.2f, "ShapeShiftNotify");
+            1.2f, "ShapeShiftRpcSetSkin");
         }
     }
 }


### PR DESCRIPTION
1.修复TOH变形bug（试验性）
2.同步TOH对愚人节模式的bug的修复
3.叛徒自票生成模式中，玩家在被取消投票后可以自票（每次会议的第一次自票会进行叛变失败提醒并取消投票，这次会议之后的自票不会再进行处理）